### PR TITLE
feat: add detection for HarmonyOS NEXT and Huawei MateBook Pro

### DIFF
--- a/src/UaDetector.Abstractions/Constants/OsFamilies.cs
+++ b/src/UaDetector.Abstractions/Constants/OsFamilies.cs
@@ -26,4 +26,5 @@ public static class OsFamilies
     public const string Windows = "Windows";
     public const string WindowsMobile = "Windows Mobile";
     public const string OtherSmartTv = "Other Smart TV";
+    public const string OpenHarmony = "OpenHarmony";
 }

--- a/src/UaDetector.Abstractions/Constants/OsNames.cs
+++ b/src/UaDetector.Abstractions/Constants/OsNames.cs
@@ -204,4 +204,5 @@ public static class OsNames
     public const string OpenSuse = "openSUSE";
     public const string Orsay = "Orsay";
     public const string NuttX = "NuttX";
+    public const string HarmonyOsNext = "HarmonyOS NEXT";
 }

--- a/src/UaDetector.Abstractions/Enums/OsCode.cs
+++ b/src/UaDetector.Abstractions/Enums/OsCode.cs
@@ -204,4 +204,5 @@ public enum OsCode
     OpenSuse = 200,
     Orsay = 201,
     NuttX = 202,
+    HarmonyOsNext = 203,
 }

--- a/src/UaDetector/Parsers/OsParser.cs
+++ b/src/UaDetector/Parsers/OsParser.cs
@@ -67,7 +67,6 @@ public sealed partial class OsParser : IOsParser
                     OsCode.PuffinOs,
                     OsCode.LeafOs,
                     OsCode.MetaHorizon,
-                    OsCode.OpenHarmony,
                     OsCode.SmartisanOs,
                 }.ToFrozenSet()
             },
@@ -208,6 +207,10 @@ public sealed partial class OsParser : IOsParser
                     OsCode.NintendoMobile,
                     OsCode.Xbox,
                 }.ToFrozenSet()
+            },
+            {
+                OsFamilies.OpenHarmony,
+                new[] { OsCode.OpenHarmony, OsCode.HarmonyOsNext }.ToFrozenSet()
             },
             { OsFamilies.OpenVms, new[] { OsCode.OpenVms }.ToFrozenSet() },
             {

--- a/src/UaDetector/Registries/OsRegistry.cs
+++ b/src/UaDetector/Registries/OsRegistry.cs
@@ -231,6 +231,7 @@ public static class OsRegistry
         { OsCode.OpenSuse, OsNames.OpenSuse },
         { OsCode.Orsay, OsNames.Orsay },
         { OsCode.NuttX, OsNames.NuttX },
+        { OsCode.HarmonyOsNext, OsNames.HarmonyOsNext },
     }.ToFrozenDictionary();
 
     internal static readonly FrozenDictionary<string, OsCode> OsNameMappings = OsCodeMappings

--- a/src/UaDetector/Resources/Browsers/browsers.json
+++ b/src/UaDetector/Resources/Browsers/browsers.json
@@ -1815,6 +1815,13 @@
     }
   },
   {
+    "regex": "com\\.huawei\\.hmos\\.browser",
+    "name": "Huawei Browser",
+    "engine": {
+      "default": "ArkWeb"
+    }
+  },
+  {
     "regex": "ZTE ?Browser/",
     "name": "ZTE Browser",
     "version": "$1"

--- a/src/UaDetector/Resources/Devices/mobiles.json
+++ b/src/UaDetector/Resources/Devices/mobiles.json
@@ -22511,6 +22511,11 @@
         "name": "BLM-00 SmartScreen"
       },
       {
+        "regex": "HAD-W24(?:[);/ ]|$)",
+        "type": 1,
+        "name": "MateBook Pro"
+      },
+      {
         "regex": "EC6108V(8|9)",
         "type": 6,
         "name": "EC6108V$1"

--- a/src/UaDetector/Resources/operating_systems.json
+++ b/src/UaDetector/Resources/operating_systems.json
@@ -476,12 +476,17 @@
     "version": "$1"
   },
   {
-    "regex": "OpenHarmony(?:[/ ](\\d+[.\\d]+))?",
+    "regex": "(?:HarmonyOS|hmos.+OpenHarmony)[-/ ]([56][.\\d]+)",
+    "name": "HarmonyOS NEXT",
+    "version": "$1"
+  },
+  {
+    "regex": "OpenHarmony(?:[-/ ](\\d+[.\\d]+))?",
     "name": "OpenHarmony",
     "version": "$1"
   },
   {
-    "regex": "HarmonyOS(?:[/ ](\\d+[.\\d]+))?",
+    "regex": "HarmonyOS(?:[-/ ](\\d+[.\\d]+))?",
     "name": "HarmonyOS",
     "version": "$1"
   },

--- a/tests/UaDetector.Abstractions.Tests/Enums/OsCodeTests.cs
+++ b/tests/UaDetector.Abstractions.Tests/Enums/OsCodeTests.cs
@@ -223,6 +223,7 @@ public class OsCodeTests
             { OsCode.OpenSuse, 200 },
             { OsCode.Orsay, 201 },
             { OsCode.NuttX, 202 },
+            { OsCode.HarmonyOsNext, 203 },
         };
 
         expectedValues.Count.ShouldBe(Enum.GetValues<OsCode>().Length);

--- a/tests/UaDetector.Tests/Fixtures/Resources/Collections/desktops_1.json
+++ b/tests/UaDetector.Tests/Fixtures/Resources/Collections/desktops_1.json
@@ -185,5 +185,30 @@
     "device": {
       "type": 1
     }
+  },
+  {
+    "userAgent": "com.huawei.hmos.browser (2in1;OpenHarmony-6.0.2.130;HAD-W24) NetworkSDK/8.0.10.309",
+    "os": {
+      "name": "HarmonyOS NEXT",
+      "code": 203,
+      "version": "6.0.2.130",
+      "family": "OpenHarmony"
+    },
+    "browser": {
+      "name": "Huawei Browser",
+      "code": 266,
+      "family": "Chrome",
+      "engine": {
+        "name": "ArkWeb"
+      }
+    },
+    "device": {
+      "type": 1,
+      "model": "MateBook Pro",
+      "brand": {
+        "name": "Huawei",
+        "code": 758
+      }
+    }
   }
 ]

--- a/tests/UaDetector.Tests/Fixtures/Resources/Collections/unknown.json
+++ b/tests/UaDetector.Tests/Fixtures/Resources/Collections/unknown.json
@@ -3518,10 +3518,10 @@
   {
     "userAgent": "Mozilla/5.0 (PC; OpenHarmony 5.0; HarmonyOS 5.0) AppleWebKit/537.36 (KHTML,like Gecko) Chrome/114.0.0.0 Safari/537.36 ArkWeb/4.1.6.1 Browser/harmony360Browser/1.0.0",
     "os": {
-      "name": "OpenHarmony",
-      "code": 188,
+      "name": "HarmonyOS NEXT",
+      "code": 203,
       "version": "5.0",
-      "family": "Android"
+      "family": "OpenHarmony"
     },
     "browser": {
       "name": "Harmony 360 Browser",

--- a/tests/UaDetector.Tests/Fixtures/Resources/browsers.json
+++ b/tests/UaDetector.Tests/Fixtures/Resources/browsers.json
@@ -14913,5 +14913,16 @@
         "name": "WebKit"
       }
     }
+  },
+  {
+    "userAgent": "com.huawei.hmos.browser (2in1;OpenHarmony-6.0.2.130;HAD-W24) NetworkSDK/8.0.10.309",
+    "browser": {
+      "name": "Huawei Browser",
+      "code": 266,
+      "family": "Chrome",
+      "engine": {
+        "name": "ArkWeb"
+      }
+    }
   }
 ]

--- a/tests/UaDetector.Tests/Fixtures/Resources/operating_systems.json
+++ b/tests/UaDetector.Tests/Fixtures/Resources/operating_systems.json
@@ -6942,7 +6942,7 @@
       "name": "OpenHarmony",
       "code": 188,
       "version": "5.1",
-      "family": "Android"
+      "family": "OpenHarmony"
     }
   },
   {
@@ -7645,6 +7645,15 @@
       "code": 134,
       "version": "7.22.2",
       "family": "GNU/Linux"
+    }
+  },
+  {
+    "userAgent": "com.huawei.hmos.browser (2in1;OpenHarmony-6.0.2.130;HAD-W24) NetworkSDK/8.0.10.309",
+    "os": {
+      "name": "HarmonyOS NEXT",
+      "code": 203,
+      "version": "6.0.2.130",
+      "family": "OpenHarmony"
     }
   }
 ]


### PR DESCRIPTION
* Improve detection for Huawei Browser

* Make OpenHarmony as a standalone OS family

* Improve version detection for HarmonyOS and OpenHarmony

* Add detection for HarmonyOS NEXT

* Add detection for Huawei MateBook Pro